### PR TITLE
Add missing CLI config credentials token to Terraform setup step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: latest
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Publish module
         run: terraform login && terraform publish


### PR DESCRIPTION
Include the `cli_config_credentials_token` in the Terraform setup to ensure proper authentication during the release process.