### PR TITLE
Update editor tab size and enhance GitHub Actions comment logic

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,14 +14,13 @@
 				"editor.bracketPairColorization.enabled": true,
 				"editor.insertSpaces": true,
 				"editor.detectIndentation": false,
-				"editor.tabSize": 4,
+				"editor.tabSize": 2,
 				"files.encoding": "utf8",
 				"[jsonc]": {
 					"editor.defaultFormatter": "vscode.json-language-features",
-					"editor.tabSize": 2
 				},
-				"[terraform]": {
-					"editor.tabSize": 2
+				"[python]": {
+					"editor.tabSize": 4
 				},
 				"terminal.integrated.scrollback": 20000
 			},

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,6 +47,15 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('Terraform Initialization')
+            })
+
             const output = `#### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
             #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
@@ -60,9 +69,18 @@ jobs:
 
             *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
 
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            })
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+              })
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              })
+            }


### PR DESCRIPTION
Adjust the editor tab size settings for better consistency and improve the handling of comments in GitHub Actions to update existing bot comments instead of creating new ones.